### PR TITLE
Report useless

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -66,7 +66,7 @@ done
 	if [[ $IGNORE_UNITTEST == "false" ]]
 	then
 		echo -ne "${GREEN} Running PHPUnit Tests.....${NC}\n\n"
-		phpunit -c tests/phpunit.xml
+		phpunit -c tests/phpunit.xml --report-useless-tests --disallow-test-output
 
 		PHPUNIT_OUT=$?
 		if [[ $PHPUNIT_OUT == 0 ]]; then


### PR DESCRIPTION
--report-useless-tests 
--disallow-test-output  

Added the above to normal CI call to both enforce greater practices and to clean up the report output.